### PR TITLE
fix(kpi): las preguntas sugeridas del agente de KPIs ahora se envían al primer intento

### DIFF
--- a/src/app/dashboard/overview/components/kpi-thread.tsx
+++ b/src/app/dashboard/overview/components/kpi-thread.tsx
@@ -121,25 +121,17 @@ const SuggestedQuestions: FC = () => {
       </p>
       <div className="flex flex-wrap gap-2">
         {suggestedQuestions.map((question, index) => (
-          <button
+          <ThreadPrimitive.Suggestion
             key={index}
-            onClick={() => {
-              const input = document.querySelector(
-                `textarea[placeholder="${t("composerPlaceholder")}"]`
-              ) as HTMLTextAreaElement;
-              if (input) {
-                input.value = question;
-                input.dispatchEvent(new Event("input", { bubbles: true }));
-                const form = input.closest("form");
-                if (form) {
-                  form.requestSubmit();
-                }
-              }
-            }}
-            className="text-xs bg-blue-50 hover:bg-blue-100 text-blue-700 px-3 py-1.5 rounded-full transition-colors"
+            prompt={question}
+            clearComposer
+            send={false}
+            asChild
           >
-            {question}
-          </button>
+            <button className="text-xs bg-blue-50 hover:bg-blue-100 text-blue-700 px-3 py-1.5 rounded-full transition-colors">
+              {question}
+            </button>
+          </ThreadPrimitive.Suggestion>
         ))}
       </div>
     </div>


### PR DESCRIPTION
El botón de pregunta sugerida rellenaba el composer manipulando el DOM directamente (querySelector + value + dispatchEvent), lo que desincroniza el value tracker interno de React y deja el estado del composer vacío aunque el textarea muestre el texto. Reemplazado por ThreadPrimitive.Suggestion, que usa la API oficial del runtime (composer().setText) y sí actualiza el estado correctamente.