### PR TITLE
Pasar trackId al enviar correos de gestion individual

### DIFF
--- a/src/app/dashboard/debtor-management/components/tabs/add-management-tab.tsx
+++ b/src/app/dashboard/debtor-management/components/tabs/add-management-tab.tsx
@@ -673,6 +673,7 @@ export const AddManagementTab = ({
                   profile,
                   managementCombination: selectedCombination,
                   bankAccountInfo: bankAccountInfoHTML,
+                  trackId: management.id,
                 });
 
                 const emailResult = await sendTrackEmail(emailPayload, session.token, profile.client_id);

--- a/src/app/dashboard/debtor-management/services/email-builder-multiple.ts
+++ b/src/app/dashboard/debtor-management/services/email-builder-multiple.ts
@@ -158,6 +158,9 @@ export function buildMultipleEmailPayload({
       is_factoring: isFactoring,
       bank_account_info: bankAccountInfo || generateBankInfoHTML(null), // Use provided or fallback
     },
+    // Best-effort: a single email can bundle multiple managements/tracks,
+    // but a debtor reply can only link to one track_id — use the first.
+    trackId: managements[0]?.id,
   };
 
   return emailPayload;

--- a/src/app/dashboard/debtor-management/services/email-builder.ts
+++ b/src/app/dashboard/debtor-management/services/email-builder.ts
@@ -18,6 +18,7 @@ interface BuildEmailPayloadParams {
   };
   managementCombination: ManagementCombination;
   bankAccountInfo?: string; // Pre-fetched bank account HTML (optional)
+  trackId?: string;
 }
 
 function formatCurrency(amount: number | string): string {
@@ -97,6 +98,7 @@ export function buildEmailPayload({
   profile,
   managementCombination,
   bankAccountInfo,
+  trackId,
 }: BuildEmailPayloadParams): EmailPayload {
   const contactEmail = managementFormData.contactValue;
 
@@ -184,6 +186,7 @@ export function buildEmailPayload({
             : "",
       email_company: clientEmail,
     },
+    trackId,
   };
 
   return emailPayload;

--- a/src/app/dashboard/debtor-management/types/email.ts
+++ b/src/app/dashboard/debtor-management/types/email.ts
@@ -33,6 +33,7 @@ export interface EmailPayload {
   to: string;
   templateId: string;
   dynamicTemplateData: EmailDynamicTemplateData;
+  trackId?: string;
 }
 
 export interface EmailManagement {
@@ -59,6 +60,7 @@ export interface EmailMultiplePayload {
   to: string;
   templateId: string;
   dynamicTemplateData: EmailMultipleDynamicTemplateData;
+  trackId?: string;
 }
 
 export interface EmailResponse {


### PR DESCRIPTION
## Summary
- Al enviar el correo de "Agregar gestion" (single y multi-gestion), se incluye el trackId del/de los track(s) creados para que el backend arme el alias Reply-To y capture la respuesta del deudor.
- Complementa services-quironix#9.

## Test plan
- [ ] Agregar gestion a un deudor de prueba con envio de email -> confirmar Reply-To en el correo recibido