### PR TITLE
fix(litigation): corregir título y descripción de la pantalla de Litigios

### DIFF
--- a/messages/es.json
+++ b/messages/es.json
@@ -1432,8 +1432,8 @@
     }
   },
   "litigation": {
-    "title": "Compensación de pagos",
-    "subDescription": "Compensación de pagos",
+    "title": "Litigios",
+    "subDescription": "Crea, normaliza y consulta el historial de litigios de tu cartera.",
     "searchPlaceholder": "Buscar",
     "historyTitle": "Historial de litigios",
     "emptyMessage": "No se encontraron litigios",


### PR DESCRIPTION
## Descripción

Corrige el encabezado de la pantalla de Litigios (Copiloto de cobranza → Litigios) que mostraba el título y descripción de otra pantalla.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `messages/es.json` | Corrige `litigation.title` y `litigation.subDescription` |

## Detalle

| Campo | Antes | Después |
|-------|-------|---------|
| `litigation.title` | `Compensación de pagos` | `Litigios` |
| `litigation.subDescription` | `Compensación de pagos` | `Crea, normaliza y consulta el historial de litigios de tu cartera.` |

> ⚠️ El bloque `paymentNetting` (pantalla legítima de Compensación de pagos bajo Conciliación) no fue modificado.

## Relacionado

QX-20 — Trello: https://trello.com/c/SfM9lmrB