### PR TITLE
feat: consulta de cuenta corriente por deudor

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1440,6 +1440,7 @@
   },
   "litigation": {
     "title": "Litigation",
+    "description": "Create, normalize, and review your portfolio's litigation history.",
     "subDescription": "Litigation",
     "searchPlaceholder": "Search",
     "historyTitle": "Litigation history",

--- a/messages/en.json
+++ b/messages/en.json
@@ -313,13 +313,13 @@
       "controlCenter": "Control Center",
       "collectorHistory": "Collector History",
       "collectionCopilot": "Collection Copilot",
-      "managementHistory": "Management History",
+      "managementHistory": "Debtors List",
       "paymentReconciliation": "Payment Reconciliation",
       "reconciliation": "Reconciliation",
       "payments": "Payments",
       "bankStatements": "Bank Statements",
       "portfolioAdmin": "Portfolio Administration",
-      "managementsListNav": "Mgmt. History",
+      "managementsListNav": "Debtor List",
       "cashFlowParams": "Cash Flow Parameters",
       "debtorsLoad": "Debtor Load & Maintenance",
       "dteLoad": "Document Load & Maintenance (DTE)",
@@ -860,6 +860,7 @@
       "noManagements": "No recent managements recorded",
       "allPrevious": "All previous managements ({count})",
       "allManagements": "All managements",
+      "viewCurrentAccount": "Current Account",
       "callOut": "Phone call",
       "email": "Email",
       "visit": "Visit",
@@ -1128,9 +1129,9 @@
       "commentPlaceholder": "Enter a comment about the normalization"
     },
     "managementsList": {
-      "pageTitle": "Management History",
-      "pageDescription": "Search and select a debtor to view their management history",
-      "pageSubDescription": "Management History",
+      "pageTitle": "Debtor List",
+      "pageDescription": "Search and select a debtor to view their management history or current account",
+      "pageSubDescription": "Debtor List",
       "collectorEngine": "Collector engine",
       "selectCompanyLabel": "Company",
       "tableTitle": "Select a debtor",
@@ -1141,7 +1142,8 @@
       "emptyState": "No debtors found",
       "rowsPerPage": "Rows per page:",
       "page": "Page {current} of {total}",
-      "viewHistory": "View history"
+      "viewHistory": "View history",
+      "viewCurrentAccount": "Current Account"
     }
   },
   "paymentPlans": {
@@ -1437,8 +1439,8 @@
     }
   },
   "litigation": {
-    "title": "Payment compensation",
-    "subDescription": "Payment compensation",
+    "title": "Litigation",
+    "subDescription": "Litigation",
     "searchPlaceholder": "Search",
     "historyTitle": "Litigation history",
     "emptyMessage": "No litigation found",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1435,7 +1435,8 @@
   },
   "litigation": {
     "title": "Litigios",
-    "subDescription": "Crea, normaliza y consulta el historial de litigios de tu cartera.",
+    "description": "Crea, normaliza y consulta el historial de litigios de tu cartera.",
+    "subDescription": "Litigios",
     "searchPlaceholder": "Buscar",
     "historyTitle": "Historial de litigios",
     "emptyMessage": "No se encontraron litigios",

--- a/messages/es.json
+++ b/messages/es.json
@@ -313,13 +313,13 @@
       "controlCenter": "Centro de Control",
       "collectorHistory": "Histórico de collector",
       "collectionCopilot": "Copiloto de cobranza",
-      "managementHistory": "Historial de gestiones",
+      "managementHistory": "Listado de Deudores",
       "paymentReconciliation": "Conciliación de pagos",
       "reconciliation": "Conciliación",
       "payments": "Pagos",
       "bankStatements": "Cartolas bancarias",
       "portfolioAdmin": "Adm. de cartera",
-      "managementsListNav": "Historial de gestiones",
+      "managementsListNav": "Listado de Deudores",
       "cashFlowParams": "Parámetros flujo de caja",
       "debtorsLoad": "Deudores",
       "dteLoad": "Documentos (DTE)",
@@ -855,6 +855,7 @@
       "noManagements": "No hay últimas gestiones registradas",
       "allPrevious": "Todas las gestiones anteriores ({count})",
       "allManagements": "Todas las gestiones",
+      "viewCurrentAccount": "Cuenta Corriente",
       "callOut": "Llamada telefónica",
       "email": "Correo electrónico",
       "visit": "Visita",
@@ -1123,9 +1124,9 @@
       "commentPlaceholder": "Ingresa un comentario sobre la normalización"
     },
     "managementsList": {
-      "pageTitle": "Historial de gestiones",
-      "pageDescription": "Busca y selecciona un deudor para ver su historial de gestiones",
-      "pageSubDescription": "Historial de gestiones",
+      "pageTitle": "Listado de Deudores",
+      "pageDescription": "Busca y selecciona un deudor para ver su historial de gestiones o su cuenta corriente",
+      "pageSubDescription": "Listado de Deudores",
       "collectorEngine": "Motor de collector",
       "selectCompanyLabel": "Empresa",
       "tableTitle": "Selecciona un deudor",
@@ -1136,7 +1137,8 @@
       "emptyState": "No se encontraron deudores",
       "rowsPerPage": "Filas por página:",
       "page": "Página {current} de {total}",
-      "viewHistory": "Ver historial"
+      "viewHistory": "Ver historial",
+      "viewCurrentAccount": "Cuenta Corriente"
     }
   },
   "paymentPlans": {

--- a/src/app/dashboard/debtor-management/components/tabs/key-reasons-tab.tsx
+++ b/src/app/dashboard/debtor-management/components/tabs/key-reasons-tab.tsx
@@ -1,14 +1,17 @@
 import { CardCollapsible } from "@/app/dashboard/components/card-collapsible";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  ArrowRight,
   CreditCard,
   FileX2,
   History,
   Scale,
   ShieldCheck,
   TriangleAlert,
+  Wallet,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
 import { CollectionProfile } from "../../types";
 import CreditRisk from "../credit-risk";
 import { DebtorChatbot } from "../debtor-chatbot";
@@ -36,6 +39,8 @@ export const KeyReasonsTab = ({
 }: KeyReasonsTabProps) => {
   const t = useTranslations("debtorManagement.keyReasonsTab");
   const tDetail = useTranslations("debtorManagement.detail");
+  const tLastManagements = useTranslations("debtorManagement.lastManagementsCard");
+  const router = useRouter();
   if (isFetchingCollectionProfile) {
     return (
       <div className="flex gap-5 h-full w-full mt-5">
@@ -154,6 +159,24 @@ export const KeyReasonsTab = ({
               debtorId={debtorId}
             />
           </CardCollapsible>
+
+          <button
+            type="button"
+            onClick={() =>
+              router.push(
+                `/dashboard/transactions/current-account?debtorId=${debtorId}`,
+              )
+            }
+            className="bg-white p-2 rounded-md w-full h-full border border-gray-400 flex justify-between items-center gap-1 text-blue-700 hover:bg-gray-50 transition-colors"
+          >
+            <div className="flex justify-start items-center gap-1">
+              <Wallet className="shrink-0" size={18} />
+              <span className="text-sm font-semibold">
+                {tLastManagements("viewCurrentAccount")}
+              </span>
+            </div>
+            <ArrowRight size={18} />
+          </button>
         </div>
       </div>
     </div>

--- a/src/app/dashboard/debtor-management/managements-list/components/debtors-table.tsx
+++ b/src/app/dashboard/debtor-management/managements-list/components/debtors-table.tsx
@@ -164,16 +164,29 @@ const DebtorsTable = ({ isFactoring }: DebtorsTableProps) => {
         id: "actions",
         header: "",
         cell: ({ row }) => (
-          <Button
-            size="sm"
-            onClick={() =>
-              router.push(
-                `/dashboard/debtor-management/${row.original.id}/managements-list?from=managements-list`
-              )
-            }
-          >
-            {t("viewHistory")}
-          </Button>
+          <div className="flex gap-2 justify-end">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() =>
+                router.push(
+                  `/dashboard/transactions/current-account?debtorId=${row.original.id}`
+                )
+              }
+            >
+              {t("viewCurrentAccount")}
+            </Button>
+            <Button
+              size="sm"
+              onClick={() =>
+                router.push(
+                  `/dashboard/debtor-management/${row.original.id}/managements-list?from=managements-list`
+                )
+              }
+            >
+              {t("viewHistory")}
+            </Button>
+          </div>
         ),
       },
     ],

--- a/src/app/dashboard/litigation/page.tsx
+++ b/src/app/dashboard/litigation/page.tsx
@@ -35,6 +35,7 @@ const Litigation = () => {
       <Main>
         <TitleSection
           title={t("title")}
+          description={t("description")}
           icon={<FileCog color="white" />}
           subDescription={t("subDescription")}
         />

--- a/src/app/dashboard/transactions/current-account/components/columns.tsx
+++ b/src/app/dashboard/transactions/current-account/components/columns.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { Badge } from "@/app/dashboard/components/badge";
+import { INVOICE_TYPES } from "@/app/dashboard/data";
+import { formatDate, formatNumber } from "@/lib/utils";
+import { ColumnDef, Row } from "@tanstack/react-table";
+import { CornerDownRight } from "lucide-react";
+import { AccountStatementRow } from "../services/types";
+
+const ROW_TYPE_LABEL: Record<AccountStatementRow["row_type"], string> = {
+  INVOICE: "Documento",
+  APPLICATION: "Aplicación",
+  PAYMENT_REMAINDER: "Pago sin conciliar",
+};
+
+const getDocumentTypeLabel = (type: string) =>
+  INVOICE_TYPES.find((c) => c.types.find((t) => t.value === type))?.types.find(
+    (t) => t.value === type
+  )?.label ?? type;
+
+const TypeCell = ({ row }: { row: Row<AccountStatementRow> }) => {
+  const original = row.original;
+  const isChild = original.row_type === "APPLICATION";
+  return (
+    <div className={isChild ? "flex items-center gap-1.5 pl-6 text-muted-foreground" : ""}>
+      {isChild && <CornerDownRight className="h-3.5 w-3.5 shrink-0" />}
+      <span className="text-sm">{ROW_TYPE_LABEL[original.row_type]}</span>
+    </div>
+  );
+};
+
+const DocumentCell = ({ row }: { row: Row<AccountStatementRow> }) => {
+  const original = row.original;
+  if (original.row_type === "INVOICE") {
+    return (
+      <div className="font-medium">
+        {getDocumentTypeLabel(original.document_type)} {original.number}
+      </div>
+    );
+  }
+  if (original.row_type === "PAYMENT_REMAINDER") {
+    return <div className="text-muted-foreground">Pago</div>;
+  }
+  return <div className="pl-6 text-muted-foreground">—</div>;
+};
+
+const DateCell = ({ row }: { row: Row<AccountStatementRow> }) => {
+  const original = row.original;
+  const date =
+    original.row_type === "INVOICE"
+      ? original.issue_date
+      : original.row_type === "APPLICATION"
+        ? original.applied_at
+        : original.payment_date;
+  if (!date) return <div>-</div>;
+  return <div>{formatDate(date)}</div>;
+};
+
+const AmountCell = ({ row }: { row: Row<AccountStatementRow> }) => {
+  const original = row.original;
+  const amount =
+    original.row_type === "INVOICE"
+      ? original.amount
+      : original.row_type === "PAYMENT_REMAINDER"
+        ? original.payment_amount
+        : null;
+  if (amount == null) return <div className="text-muted-foreground">—</div>;
+  return <div>{formatNumber(amount)}</div>;
+};
+
+const AppliedCell = ({ row }: { row: Row<AccountStatementRow> }) => {
+  const original = row.original;
+  const applied =
+    original.row_type === "INVOICE"
+      ? original.amount - original.balance
+      : original.row_type === "APPLICATION"
+        ? original.amount_applied
+        : original.payment_amount - original.remaining_balance;
+  return <div>{formatNumber(applied)}</div>;
+};
+
+const BalanceCell = ({ row }: { row: Row<AccountStatementRow> }) => {
+  const original = row.original;
+  const balance =
+    original.row_type === "INVOICE"
+      ? original.balance
+      : original.row_type === "PAYMENT_REMAINDER"
+        ? original.remaining_balance
+        : null;
+  if (balance == null) return <div className="text-muted-foreground">—</div>;
+  return <div className="font-medium">{formatNumber(balance)}</div>;
+};
+
+const StatusCell = ({ row }: { row: Row<AccountStatementRow> }) => {
+  const original = row.original;
+  if (original.row_type === "APPLICATION") {
+    return <div className="text-muted-foreground">—</div>;
+  }
+  const isOpen = original.status === "open";
+  return (
+    <Badge
+      variant={isOpen ? "warning" : "success"}
+      text={isOpen ? "Abierto" : "Cerrado"}
+    />
+  );
+};
+
+export const columns: ColumnDef<AccountStatementRow>[] = [
+  {
+    id: "row_type",
+    header: "Tipo",
+    cell: ({ row }) => <TypeCell row={row} />,
+  },
+  {
+    id: "document",
+    header: "Documento / Nº",
+    cell: ({ row }) => <DocumentCell row={row} />,
+  },
+  {
+    id: "date",
+    header: "Fecha",
+    cell: ({ row }) => <DateCell row={row} />,
+  },
+  {
+    id: "amount",
+    header: "Monto",
+    cell: ({ row }) => <AmountCell row={row} />,
+  },
+  {
+    id: "applied",
+    header: "Aplicado",
+    cell: ({ row }) => <AppliedCell row={row} />,
+  },
+  {
+    id: "balance",
+    header: "Saldo",
+    cell: ({ row }) => <BalanceCell row={row} />,
+  },
+  {
+    id: "status",
+    header: "Estatus",
+    cell: ({ row }) => <StatusCell row={row} />,
+  },
+];

--- a/src/app/dashboard/transactions/current-account/hooks/useAccountStatement.ts
+++ b/src/app/dashboard/transactions/current-account/hooks/useAccountStatement.ts
@@ -1,0 +1,99 @@
+import { getAccountStatement } from "@/app/dashboard/transactions/current-account/services";
+import { AccountStatementStatus } from "@/app/dashboard/transactions/current-account/services/types";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+
+interface UseAccountStatementParams {
+  accessToken: string;
+  clientId: string;
+  debtorId: string;
+  initialPage?: number;
+  initialLimit?: number;
+}
+
+const ACCOUNT_STATEMENT_QUERY_KEY = "account-statement";
+
+export const useAccountStatement = ({
+  accessToken,
+  clientId,
+  debtorId,
+  initialPage = 1,
+  initialLimit = 15,
+}: UseAccountStatementParams) => {
+  const [currentPage, setCurrentPage] = useState(initialPage);
+  const [currentLimit, setCurrentLimit] = useState(initialLimit);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [status, setStatus] = useState<AccountStatementStatus>("all");
+
+  const queryFn = useCallback(
+    () =>
+      getAccountStatement(accessToken, clientId, debtorId, {
+        page: currentPage,
+        limit: currentLimit,
+        search: searchTerm,
+        status,
+      }),
+    [accessToken, clientId, debtorId, currentPage, currentLimit, searchTerm, status]
+  );
+
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: [
+      `${ACCOUNT_STATEMENT_QUERY_KEY}-${clientId}-${debtorId}`,
+      currentPage,
+      currentLimit,
+      searchTerm,
+      status,
+    ],
+    queryFn,
+    enabled: !!accessToken && !!clientId && !!debtorId,
+    staleTime: 30 * 1000,
+    gcTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    retry: 2,
+  });
+
+  const handlePaginationChange = useCallback((page: number, limit: number) => {
+    setCurrentPage(page);
+    setCurrentLimit(limit);
+  }, []);
+
+  const handleSearchChange = useCallback((search: string) => {
+    setSearchTerm(search);
+    setCurrentPage(1);
+  }, []);
+
+  const handleStatusChange = useCallback((next: AccountStatementStatus) => {
+    setStatus(next);
+    setCurrentPage(1);
+  }, []);
+
+  const queryClient = useQueryClient();
+  const invalidateAccountStatement = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: [`${ACCOUNT_STATEMENT_QUERY_KEY}-${clientId}-${debtorId}`],
+    });
+  }, [queryClient, clientId, debtorId]);
+
+  return {
+    rows: data?.data || [],
+    pagination: data?.pagination || {
+      page: currentPage,
+      limit: currentLimit,
+      total: 0,
+      totalPages: 1,
+      hasNext: false,
+      hasPrevious: false,
+    },
+    isLoading,
+    isError,
+    error,
+    refetch,
+    handlePaginationChange,
+    handleSearchChange,
+    status,
+    handleStatusChange,
+    currentPage,
+    currentLimit,
+    invalidateAccountStatement,
+  };
+};

--- a/src/app/dashboard/transactions/current-account/page.tsx
+++ b/src/app/dashboard/transactions/current-account/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import Header from "@/app/dashboard/components/header";
+import { Main } from "@/app/dashboard/components/main";
+import TitleSection from "@/app/dashboard/components/title-section";
+import { Button } from "@/components/ui/button";
+import { ExportExcelModal } from "@/components/ui/export-excel-modal";
+import Language from "@/components/ui/language";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { useProfileContext } from "@/context/ProfileContext";
+import { VisibilityState } from "@tanstack/react-table";
+import { FileDown, Wallet } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { DataTableDynamicColumns } from "../../components/data-table-dynamic-columns";
+import { columns } from "./components/columns";
+import { useAccountStatement } from "./hooks/useAccountStatement";
+import { updateCurrentAccountTableProfile } from "./services/profile";
+import { AccountStatementRow, AccountStatementStatus } from "./services/types";
+
+const CurrentAccountPage = () => {
+  const { session, profile } = useProfileContext();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const debtorId = searchParams.get("debtorId") || "";
+  const [exportOpen, setExportOpen] = useState(false);
+
+  const [columnConfiguration, setColumnConfiguration] = useState<
+    Array<{ name: string; is_visible: boolean }>
+  >([
+    { name: "row_type", is_visible: true },
+    { name: "document", is_visible: true },
+    { name: "date", is_visible: true },
+    { name: "amount", is_visible: true },
+    { name: "applied", is_visible: true },
+    { name: "balance", is_visible: true },
+    { name: "status", is_visible: true },
+  ]);
+
+  const columnVisibility = useMemo(() => {
+    const visibility: VisibilityState = {};
+    columnConfiguration.forEach((col) => {
+      visibility[col.name] = col.is_visible;
+    });
+    return visibility;
+  }, [columnConfiguration]);
+
+  const columnLabels = useMemo(
+    () => ({
+      row_type: "Tipo",
+      document: "Documento / Nº",
+      date: "Fecha",
+      amount: "Monto",
+      applied: "Aplicado",
+      balance: "Saldo",
+      status: "Estatus",
+    }),
+    []
+  );
+
+  useEffect(() => {
+    if (profile?.profile?.current_account_table?.length > 0) {
+      const savedConfig = profile.profile.current_account_table;
+      if (Array.isArray(savedConfig)) {
+        setColumnConfiguration(savedConfig);
+      }
+    }
+  }, [profile?.profile]);
+
+  const {
+    rows,
+    pagination,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    handlePaginationChange,
+    handleSearchChange,
+    status,
+    handleStatusChange,
+    currentLimit,
+  } = useAccountStatement({
+    accessToken: session?.token || "",
+    clientId: profile?.client?.id || "",
+    debtorId,
+    initialPage: 1,
+    initialLimit: 15,
+  });
+
+  useEffect(() => {
+    if (debtorId) refetch();
+  }, [debtorId]);
+
+  const handleUpdateColumns = async (
+    config?: Array<{ name: string; is_visible: boolean }>
+  ) => {
+    try {
+      const configToSave = config || columnConfiguration;
+
+      const response = await updateCurrentAccountTableProfile({
+        accessToken: session?.token,
+        clientId: profile?.client_id,
+        userId: profile?.id,
+        currentAccountTable: configToSave,
+      });
+
+      if (response.success) {
+        if (config) setColumnConfiguration(config);
+      } else {
+        toast.error(response.message);
+      }
+    } catch (err) {
+      console.error("Error al actualizar configuración de columnas:", err);
+      toast.error("Error al guardar la configuración de columnas");
+    }
+  };
+
+  const TableSkeleton = () => (
+    <>
+      {Array.from({ length: currentLimit }).map((_, index) => (
+        <TableRow key={index}>
+          <TableCell>
+            <Skeleton className="h-5 w-20" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-5 w-32" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-5 w-24" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-5 w-24" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-5 w-24" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-5 w-24" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-5 w-20" />
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
+
+  if (!debtorId) {
+    return (
+      <>
+        <Header fixed>
+          <Language />
+        </Header>
+        <Main>
+          <TitleSection
+            title="Cuenta Corriente"
+            description="Consulta de documentos, aplicaciones de pago y pagos no conciliados por deudor."
+            icon={<Wallet color="white" />}
+            subDescription="Transacciones"
+          />
+          <div className="flex justify-center items-center h-64">
+            <div className="text-center bg-amber-50 border border-amber-200 rounded-lg p-6">
+              <p className="text-amber-700 font-medium mb-3">
+                No se especificó un deudor para consultar.
+              </p>
+              <Button
+                variant="outline"
+                onClick={() =>
+                  router.push("/dashboard/debtor-management/managements-list")
+                }
+              >
+                Ir a Listado de Deudores
+              </Button>
+            </div>
+          </div>
+        </Main>
+      </>
+    );
+  }
+
+  if (isError) {
+    return (
+      <>
+        <Header fixed>
+          <Language />
+        </Header>
+        <Main>
+          <TitleSection
+            title="Cuenta Corriente"
+            description="Consulta de documentos, aplicaciones de pago y pagos no conciliados por deudor."
+            icon={<Wallet color="white" />}
+            subDescription="Transacciones"
+          />
+          <div className="flex justify-center items-center h-64">
+            <div className="text-center">
+              <div className="bg-red-50 border border-red-200 rounded-lg p-6">
+                <p className="text-red-600 font-medium mb-2">
+                  Error al cargar la cuenta corriente
+                </p>
+                <p className="text-red-500 text-sm mb-4">
+                  {error?.message || "Error desconocido"}
+                </p>
+                <Button
+                  onClick={() => refetch()}
+                  variant="outline"
+                  className="border-red-200 text-red-600 hover:bg-red-50"
+                >
+                  Reintentar
+                </Button>
+              </div>
+            </div>
+          </div>
+        </Main>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header fixed>
+        <Language />
+      </Header>
+      <Main>
+        <TitleSection
+          title="Cuenta Corriente"
+          description="Consulta de documentos, aplicaciones de pago y pagos no conciliados por deudor."
+          icon={<Wallet color="white" />}
+          subDescription="Transacciones"
+        />
+        <div className="mt-5 border border-gray-200 rounded-md p-3">
+          <DataTableDynamicColumns<AccountStatementRow, unknown>
+            columns={columns}
+            data={rows}
+            pagination={pagination}
+            onPaginationChange={handlePaginationChange}
+            onSearchChange={handleSearchChange}
+            isServerSideLoading={isLoading}
+            loadingComponent={<TableSkeleton />}
+            emptyMessage="No hay movimientos para este deudor."
+            pageSize={currentLimit}
+            pageSizeOptions={[15, 20, 25, 30, 40, 50]}
+            enableGlobalFilter={true}
+            searchPlaceholder="Buscar por número de documento o pago"
+            showPagination={true}
+            enableColumnFilter={true}
+            initialColumnVisibility={columnVisibility}
+            columnLabels={columnLabels}
+            handleSuccessButton={handleUpdateColumns}
+            initialColumnConfiguration={columnConfiguration}
+            title="Cuenta Corriente"
+            description="Documentos con sus aplicaciones de pago y pagos no conciliados"
+            rowClassName={(row: AccountStatementRow) =>
+              row.row_type === "APPLICATION"
+                ? "bg-gray-50"
+                : row.row_type === "INVOICE" && row.is_credit_or_debit_note
+                  ? "bg-red-50"
+                  : ""
+            }
+            filterInputs={
+              <Select
+                value={status}
+                onValueChange={(value) =>
+                  handleStatusChange(value as AccountStatementStatus)
+                }
+              >
+                <SelectTrigger className="w-[160px]">
+                  <SelectValue placeholder="Estatus" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todas</SelectItem>
+                  <SelectItem value="open">Abiertas</SelectItem>
+                  <SelectItem value="closed">Cerradas</SelectItem>
+                </SelectContent>
+              </Select>
+            }
+            ctaNode={
+              <Button variant="outline" onClick={() => setExportOpen(true)}>
+                <FileDown className="h-4 w-4 mr-2 text-orange-400" />
+                Exportar
+              </Button>
+            }
+          />
+        </div>
+        <ExportExcelModal
+          open={exportOpen}
+          onOpenChange={setExportOpen}
+          schema="CURRENT_ACCOUNT"
+          accessToken={session?.token || ""}
+          clientId={profile?.client?.id || ""}
+          debtorId={debtorId}
+        />
+      </Main>
+    </>
+  );
+};
+
+export default CurrentAccountPage;

--- a/src/app/dashboard/transactions/current-account/services/index.ts
+++ b/src/app/dashboard/transactions/current-account/services/index.ts
@@ -1,0 +1,42 @@
+import { AccountStatementResponse, AccountStatementStatus } from "./types";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+interface AccountStatementParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+  status?: AccountStatementStatus;
+}
+
+export const getAccountStatement = async (
+  accessToken: string,
+  clientId: string,
+  debtorId: string,
+  params?: AccountStatementParams
+): Promise<AccountStatementResponse> => {
+  const queryParams = new URLSearchParams();
+
+  if (params?.page) queryParams.append("page", params.page.toString());
+  if (params?.limit) queryParams.append("limit", params.limit.toString());
+  if (params?.search) queryParams.append("search", params.search);
+  if (params?.status) queryParams.append("status", params.status);
+
+  const queryString = queryParams.toString();
+  const url = `${API_URL}/v2/clients/${clientId}/reconciliation/debtors/${debtorId}/account-statement${
+    queryString ? `?${queryString}` : ""
+  }`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch account statement");
+  }
+
+  return response.json();
+};

--- a/src/app/dashboard/transactions/current-account/services/profile.ts
+++ b/src/app/dashboard/transactions/current-account/services/profile.ts
@@ -1,0 +1,52 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export const updateCurrentAccountTableProfile = async ({
+  accessToken,
+  clientId,
+  userId,
+  currentAccountTable,
+}: {
+  accessToken: string;
+  clientId: string;
+  userId: string;
+  currentAccountTable: Array<{ name: string; is_visible: boolean }>;
+}) => {
+  try {
+    const response = await fetch(
+      `${API_URL}/v2/clients/${clientId}/users/${userId}/profile`,
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          current_account_table: currentAccountTable,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      return {
+        success: false,
+        message: errorData?.message || "Error al actualizar el perfil",
+        data: null,
+      };
+    }
+
+    const data = await response.json();
+    return {
+      success: true,
+      message: "Perfil actualizado correctamente",
+      data,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      success: false,
+      message: "Error al actualizar el perfil",
+      data: null,
+    };
+  }
+};

--- a/src/app/dashboard/transactions/current-account/services/types.ts
+++ b/src/app/dashboard/transactions/current-account/services/types.ts
@@ -1,0 +1,52 @@
+export type AccountStatementStatus = "open" | "closed" | "all";
+
+export interface InvoiceStatementRow {
+  row_type: "INVOICE";
+  id: string;
+  document_type: string;
+  number: string;
+  issue_date: string;
+  due_date: string;
+  amount: number;
+  balance: number;
+  status: "open" | "closed";
+  applications_count: number;
+  is_credit_or_debit_note: boolean;
+}
+
+export interface ApplicationStatementRow {
+  row_type: "APPLICATION";
+  id: string;
+  invoice_id: string;
+  payment_id: string | null;
+  applied_at: string;
+  amount_applied: number;
+}
+
+export interface PaymentRemainderStatementRow {
+  row_type: "PAYMENT_REMAINDER";
+  id: string;
+  payment_date: string;
+  payment_amount: number;
+  remaining_balance: number;
+  status: "open" | "closed";
+}
+
+export type AccountStatementRow =
+  | InvoiceStatementRow
+  | ApplicationStatementRow
+  | PaymentRemainderStatementRow;
+
+export interface AccountStatementPaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+}
+
+export interface AccountStatementResponse {
+  data: AccountStatementRow[];
+  pagination: AccountStatementPaginationMeta;
+}

--- a/src/components/ui/export-excel-modal.tsx
+++ b/src/components/ui/export-excel-modal.tsx
@@ -23,9 +23,17 @@ interface ExportExcelModalProps {
   schema: ExportSchema;
   accessToken: string;
   clientId: string;
+  /** Required when schema is CURRENT_ACCOUNT — ignored by every other schema. */
+  debtorId?: string;
 }
 
-const STATUS_SCHEMAS: ExportSchema[] = ["INVOICES", "LITIGATION"];
+const STATUS_SCHEMAS: ExportSchema[] = ["INVOICES", "LITIGATION", "CURRENT_ACCOUNT"];
+
+// CURRENT_ACCOUNT exports the debtor's full history regardless of date —
+// the period picker below doesn't apply to it (PRD_consulta_cuenta_corriente.md §8.9.6).
+// The shared export endpoint still requires a valid from/to pair, so a
+// harmless (and always-valid) 3-month window is sent and ignored server-side.
+const SCHEMAS_WITHOUT_PERIOD: ExportSchema[] = ["CURRENT_ACCOUNT"];
 
 const MAX_SELECTION = 3;
 
@@ -94,7 +102,7 @@ function canAdd(key: string, selected: string[]): boolean {
 
 const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
-export function ExportExcelModal({ open, onOpenChange, schema, accessToken, clientId }: ExportExcelModalProps) {
+export function ExportExcelModal({ open, onOpenChange, schema, accessToken, clientId, debtorId }: ExportExcelModalProps) {
   const t = useTranslations("exportExcel");
   const [selected, setSelected] = useState<string[]>([]);
   const [status, setStatus] = useState<ExportStatus>("all");
@@ -107,9 +115,11 @@ export function ExportExcelModal({ open, onOpenChange, schema, accessToken, clie
     PAYMENT_PLANS: t("schemaPaymentPlans"),
     PAYMENTS: t("schemaPayments"),
     MANAGEMENTS: t("schemaManagements"),
+    CURRENT_ACCOUNT: "Cuenta Corriente",
   };
 
   const showStatus = STATUS_SCHEMAS.includes(schema);
+  const showPeriod = !SCHEMAS_WITHOUT_PERIOD.includes(schema);
   const options = useMemo(() => buildMonthOptions(), [open]);
 
   const rangeLabel = useMemo(() => {
@@ -135,15 +145,18 @@ export function ExportExcelModal({ open, onOpenChange, schema, accessToken, clie
   };
 
   const handleExport = async () => {
-    if (selected.length === 0) { toast.error(t("toastSelectMonth")); return; }
+    if (showPeriod && selected.length === 0) { toast.error(t("toastSelectMonth")); return; }
     setIsLoading(true);
     try {
-      const { from, to } = getRangeFromSelection(selected, options);
+      const { from, to } = showPeriod
+        ? getRangeFromSelection(selected, options)
+        : { from: startOfMonth(subMonths(new Date(), 2)), to: new Date() };
       const { blob, filename } = await exportExcel({
         accessToken, clientId, schema,
         from: from.toISOString(),
         to: to.toISOString(),
         status: showStatus ? status : undefined,
+        debtorId,
       });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
@@ -187,6 +200,7 @@ export function ExportExcelModal({ open, onOpenChange, schema, accessToken, clie
         <div className="px-5 py-4 flex flex-col gap-4">
 
           {/* Selector de meses */}
+          {showPeriod && (
           <div className="flex flex-col gap-2">
             <div className="flex flex-col gap-0.5">
               <span className="text-xs font-semibold text-foreground">{t("period")}</span>
@@ -248,8 +262,9 @@ export function ExportExcelModal({ open, onOpenChange, schema, accessToken, clie
               <span className="tabular-nums">{rangeLabel ?? "—"}</span>
             </div>
           </div>
+          )}
 
-          {/* Estado (solo para INVOICES y LITIGATION) */}
+          {/* Estado (solo para INVOICES, LITIGATION y CURRENT_ACCOUNT) */}
           {showStatus && (
             <div className="flex flex-col gap-2">
               <span className="text-xs font-semibold text-foreground">{t("status")}</span>
@@ -289,7 +304,7 @@ export function ExportExcelModal({ open, onOpenChange, schema, accessToken, clie
           <Button
             size="sm"
             onClick={handleExport}
-            disabled={isLoading || selected.length === 0}
+            disabled={isLoading || (showPeriod && selected.length === 0)}
             className="gap-1.5"
           >
             {isLoading ? (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,6 +34,7 @@ const ROUTE_SCOPE_MAP: Record<string, string> = {
   "/dashboard/transactions/dte": "client.transactions.dte",
   "/dashboard/transactions/payments": "client.transactions.payments",
   "/dashboard/transactions/movements": "client.transactions.movements",
+  "/dashboard/transactions/current-account": "client.transactions.current_account",
 
   // Debtor management
   "/dashboard/debtor-management": "client.debtor_management",

--- a/src/services/reports/index.ts
+++ b/src/services/reports/index.ts
@@ -6,7 +6,8 @@ export type ExportSchema =
   | "LITIGATION"
   | "PAYMENT_PLANS"
   | "PAYMENTS"
-  | "MANAGEMENTS";
+  | "MANAGEMENTS"
+  | "CURRENT_ACCOUNT";
 
 export type ExportStatus = "open" | "closed" | "all";
 
@@ -17,6 +18,7 @@ interface ExportExcelParams {
   from: string;
   to: string;
   status?: ExportStatus;
+  debtorId?: string;
 }
 
 export async function exportExcel({
@@ -26,10 +28,14 @@ export async function exportExcel({
   from,
   to,
   status,
+  debtorId,
 }: ExportExcelParams): Promise<{ blob: Blob; filename: string }> {
   const params = new URLSearchParams({ schema, from, to });
   if (status && status !== "all") {
     params.set("status", status);
+  }
+  if (debtorId) {
+    params.set("debtorId", debtorId);
   }
 
   const response = await fetch(


### PR DESCRIPTION
## Resumen
- Nueva pantalla `transactions/current-account` (tabla configurable, filtro de estado, export a Excel), clonando el patron de `transactions/dte`.
- Dos puntos de entrada: boton "Cuenta Corriente" en el listado de deudores (`debtor-management/managements-list`) y boton bajo "Ultimas gestiones" en el detalle del deudor.
- Rename de "Historial de Gestiones" a "Listado de Deudores" en `managements-list` (titulo de pagina + nav del sidebar).
- Fix menor de paso: la pagina de Litigios usaba `subDescription` (label corto junto al icono) para el texto largo explicativo; se agrego el prop `description` que faltaba en `TitleSection`.

Implementa `PRDs/PRD_consulta_cuenta_corriente.md`. Depende de:
https://github.com/Quironix/services-quironix/pull/16
https://github.com/Quironix/bff-quironix/pull/6

## Test plan
- [x] Probado en navegador con sesion real: ambas entradas, filtro de estado, export a Excel, indentacion de filas de aplicacion
- [x] Typecheck limpio