### PR TITLE
fix(export): mostrar mes actual siempre en el exportador de Excel

### DIFF
--- a/src/components/ui/export-excel-modal.tsx
+++ b/src/components/ui/export-excel-modal.tsx
@@ -38,7 +38,7 @@ interface MonthOption {
 
 function buildMonthOptions(): MonthOption[] {
   const now = new Date();
-  const includeCurrentMonth = now.getDate() > 15;
+  const includeCurrentMonth = true;
   const startOffset = includeCurrentMonth ? 0 : 1;
   const options: MonthOption[] = [];
 


### PR DESCRIPTION
## Descripción

El exportador de Excel ocultaba el mes en curso cuando el día del mes era ≤ 15, debido a una regla de negocio hardcodeada. Según confirmación del cliente, el mes actual debe estar siempre disponible para exportar, con el rango `to` ajustado al día actual.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `src/components/ui/export-excel-modal.tsx` | Elimina restricción del día 15 para mostrar el mes en curso |

## Detalle

```ts
// Antes
const includeCurrentMonth = now.getDate() > 15;

// Después
const includeCurrentMonth = true;
```

La lógica de `to = hoy a las 23:59:59` ya existía y no requirió cambios — el mes en curso siempre exporta hasta el día actual.

## Relacionado

QX-14 — Trello: https://trello.com/c/n1VZN6UK