### PR TITLE
feat: mostrar numero de pago en las aplicaciones de cuenta corriente

### DIFF
--- a/src/app/dashboard/transactions/current-account/components/columns.tsx
+++ b/src/app/dashboard/transactions/current-account/components/columns.tsx
@@ -41,7 +41,11 @@ const DocumentCell = ({ row }: { row: Row<AccountStatementRow> }) => {
   if (original.row_type === "PAYMENT_REMAINDER") {
     return <div className="text-muted-foreground">Pago</div>;
   }
-  return <div className="pl-6 text-muted-foreground">—</div>;
+  return (
+    <div className="pl-6 text-muted-foreground">
+      {original.payment_number ? `Pago ${original.payment_number}` : "—"}
+    </div>
+  );
 };
 
 const DateCell = ({ row }: { row: Row<AccountStatementRow> }) => {

--- a/src/app/dashboard/transactions/current-account/services/types.ts
+++ b/src/app/dashboard/transactions/current-account/services/types.ts
@@ -19,6 +19,7 @@ export interface ApplicationStatementRow {
   id: string;
   invoice_id: string;
   payment_id: string | null;
+  payment_number: string | null;
   applied_at: string;
   amount_applied: number;
 }


### PR DESCRIPTION
## Summary
- La tabla de Cuenta Corriente ahora muestra el numero de pago en la columna "Documento / Nº" para las filas de tipo Aplicacion (antes quedaba en blanco).
- Depende del backend en https://github.com/Quironix/services-quironix/pull/19 (agrega `payment_number` a la respuesta del endpoint).

## Test plan
- [ ] `npm run type-check` (ya corrido localmente, limpio)
- [ ] Abrir Cuenta Corriente de un deudor con facturas que tengan pagos aplicados y confirmar que la fila "Aplicacion" muestra "Pago <numero>" en vez de "—"